### PR TITLE
php.ini 修正

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,5 +1,4 @@
 [Date]
 date.timezone = "Asia/Tokyo"
 [mbstring]
-mbstring.internal_encoding = "UTF-8"
 mbstring.language = "Japanese"


### PR DESCRIPTION
以下の warning の対応
```
Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
```