### PR TITLE
PHP環境における Node.js ビルドエラーの解消

### DIFF
--- a/php/laravel/docker/php/Dockerfile
+++ b/php/laravel/docker/php/Dockerfile
@@ -1,13 +1,19 @@
 FROM php:8.0-fpm
 
-# --- Node.js のインストール（公式イメージからバイナリをコピー） ---
-COPY --from=node:20-slim /usr/local/bin /usr/local/bin
-COPY --from=node:20-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+# --- Node.js のインストール（OSバージョンを bullseye に固定して整合性を確保） ---
+COPY --from=node:20-bullseye-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:20-bullseye-slim /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+COPY --from=node:20-bullseye-slim /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/corepack
+
+# 実行するためのショートカット（シンボリックリンク）を作成
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
 
 COPY php.ini /usr/local/etc/php/
 
 # パッケージインストールを整理
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     mariadb-client \
     vim \
@@ -17,8 +23,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Composer のインストール（公式イメージからコピー） ---
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+# --- Composer のインストール（バージョンを 2.2 系に固定） ---
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /composer

--- a/php/laravel/docker/php/Dockerfile
+++ b/php/laravel/docker/php/Dockerfile
@@ -1,28 +1,27 @@
 FROM php:8.0-fpm
+
+# --- Node.js のインストール（公式イメージからバイナリをコピー） ---
+COPY --from=node:20-slim /usr/local/bin /usr/local/bin
+COPY --from=node:20-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+
 COPY php.ini /usr/local/etc/php/
 
-RUN apt-get update \
-  && apt-get install -y zlib1g-dev mariadb-client vim libzip-dev \
-  && docker-php-ext-install zip pdo_mysql &&\
-  curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
-  apt-get install -y nodejs && \
-  npm install npm@latest -g && \
-  apt-get -y install libpq-dev &&\
-  docker-php-ext-install pdo_pgsql
+# パッケージインストールを整理
+RUN apt-get update && apt-get install -y \
+    zlib1g-dev \
+    mariadb-client \
+    vim \
+    libzip-dev \
+    libpq-dev \
+    && docker-php-ext-install zip pdo_mysql pdo_pgsql \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-#Composer install
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
+# --- Composer のインストール（公式イメージからコピー） ---
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-
 ENV COMPOSER_HOME /composer
-
 ENV PATH $PATH:/composer/vendor/bin
 
-
 WORKDIR /var/www
-
-RUN composer global require "laravel/installer"


### PR DESCRIPTION
### **内容（概要）**

PHPアプリ側の Docker ビルドにおいて、Node.js 14 のリポジトリ鍵エラーにより `start.sh` 等のセットアップが中断される問題を修正しました。あわせて、配布時のビルド安定性とイメージの軽量化を図っています。

#### **修正前の問題（ビルドエラー）**

PHPコンテナのビルド中、NodeSource リポジトリの署名検証に失敗し、`apt-get update` が停止していました。

```text
W: GPG error: https://deb.nodesource.com/node_14.x bullseye InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1655A0AB68576280
E: The repository 'https://deb.nodesource.com/node_14.x bullseye InRelease' is not signed.
Error executing command, exiting

```

#### **主な変更点**

* **PHPコンテナ内の Node.js 環境刷新**:
* 署名エラーの発生する古いインストール方式を廃止。
* 公式 `node:20-slim` イメージからバイナリをコピーする方式に変更し、Node.js 20 (LTS) での安定動作を確保しました。


* **Composer バージョンの固定**:
* 常に最新を取得する不安定な方式から `composer:2` への指定に変更。将来のツール更新によるビルド失敗を防止しました。


* **Dockerfile の最適化**:
* レイヤーの統合と不要なキャッシュ削除により、イメージサイズを削減。
* サンプルアプリの動作には不要な `laravel/installer` の global インストールを削除し、ビルドを高速化しました。

